### PR TITLE
Change: マージキューのテストはmerge_groupのだけ走るようにする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,10 @@ on:
   push:
     branches:
       - main
+      - "!gh-readonly-queue/**"
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,8 @@
 name: Test
 on:
   push:
-    branches:
-      - main
-      - "!gh-readonly-queue/**"
+    branches-ignore:
+      - "gh-readonly-queue/**"
   pull_request:
   merge_group:
     types: [checks_requested]


### PR DESCRIPTION
## 内容

タイトル通りです。この後にマージキューでだけ落ちるテストを投げます。

## 関連 Issue

- ref: #12 

## スクリーンショット・動画など

（なし）

## その他

（なし）